### PR TITLE
Add basic color support to HTML tags and attributes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # **eppz!** (C# theme for Unity)
 ## **Change log**
 
+* **1.2.42** - *2020-07-22* (Html_support)
+    + `.html` coloring (basic)
+        + Tag name and tag attribute coloring
 
 * **1.2.41** - *2017-07-20*
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "eppz-code",
     "displayName": "eppz! (C# theme for Unity)",
-    "version": "1.2.41",
+    "version": "1.2.42",
     "description": "Carefully designed colors with meanings.",
     "keywords":
     [

--- a/package.json
+++ b/package.json
@@ -3,76 +3,128 @@
     "displayName": "eppz! (C# theme for Unity)",
     "version": "1.2.42",
     "description": "Carefully designed colors with meanings.",
-    "keywords":
-    [
-        "unity 3d", "c#", "theme", "syntax coloring", "class",
-        "unity", "unity3d", "unity 3d",
-        "c#", "c sharp", "csharp", "c-sharp", "cs", ".cs", "*.cs",
-        "color", "colour", "coloring", "colouring",
-        "theme", "color theme", "scheme", "color scheme",
-        "syntax", "syntax coloring", "syntax colouring",
-        "language", "language grammar", "language extension",
-        "code", "script", "class", "classes", "type", "types",
-        "unity code", "unity script", "unity class", "unity classes", "unity type", "unity types",       
-        "vscode", "vs code", "visual studio", "visual studio code",
-        "eppz", "eppz!"
+    "keywords": [
+        "unity 3d",
+        "c#",
+        "theme",
+        "syntax coloring",
+        "class",
+        "unity",
+        "unity3d",
+        "unity 3d",
+        "c#",
+        "c sharp",
+        "csharp",
+        "c-sharp",
+        "cs",
+        ".cs",
+        "*.cs",
+        "color",
+        "colour",
+        "coloring",
+        "colouring",
+        "theme",
+        "color theme",
+        "scheme",
+        "color scheme",
+        "syntax",
+        "syntax coloring",
+        "syntax colouring",
+        "language",
+        "language grammar",
+        "language extension",
+        "code",
+        "script",
+        "class",
+        "classes",
+        "type",
+        "types",
+        "unity code",
+        "unity script",
+        "unity class",
+        "unity classes",
+        "unity type",
+        "unity types",
+        "vscode",
+        "vs code",
+        "visual studio",
+        "visual studio code",
+        "eppz",
+        "eppz!"
     ],
     "publisher": "eppz",
     "license": "CC-BY-NC-4.0",
-    "author":
-    {
+    "author": {
         "name": "Geri Borbás (eppz!)",
         "url": "https://twitter.com/_eppz"
     },
     "icon": "images/eppz-Code_icon_128px.png",
-    "galleryBanner":
-    {
+    "galleryBanner": {
         "color": "#2b2d35",
         "theme": "dark"
     },
-    "repository":
-    {
+    "repository": {
         "type": "git",
         "url": "https://github.com/eppz/VSCode.Extension.eppz_Code"
     },
     "homepage": "https://github.com/eppz/VSCode.Extension.eppz_Code/blob/master/README.md",
-    "bugs": { "url": "https://github.com/eppz/VSCode.Extension.eppz_Code/issues" },
-    "categories": [ "Languages", "Themes" ],
-    "engines": { "vscode": "^1.10.0" },
-    "contributes":
-    {
-        "languages":
-        [
+    "bugs": {
+        "url": "https://github.com/eppz/VSCode.Extension.eppz_Code/issues"
+    },
+    "categories": [
+        "Languages",
+        "Themes"
+    ],
+    "engines": {
+        "vscode": "^1.10.0"
+    },
+    "contributes": {
+        "languages": [
             {
                 "id": "official",
-                "aliases": [ "C# (official)" ],
-                "extensions": [ ".official" ],
+                "aliases": [
+                    "C# (official)"
+                ],
+                "extensions": [
+                    ".official"
+                ],
                 "configuration": "./language-configuration.json"
             },
             {
                 "id": "unity",
-                "aliases": [ "C# (Unity)" ],
-                "extensions": [ ".unity" ],
+                "aliases": [
+                    "C# (Unity)"
+                ],
+                "extensions": [
+                    ".unity"
+                ],
                 "configuration": "./language-configuration.json"
             },
             {
                 "id": "extensions",
-                "aliases": [ "C# (extensions)" ],
-                "extensions": [ ".extensions" ],
+                "aliases": [
+                    "C# (extensions)"
+                ],
+                "extensions": [
+                    ".extensions"
+                ],
                 "configuration": "./language-configuration.json"
             },
             {
                 "id": "extended",
-                "aliases": [ "C# (extended)" ],
-                "extensions": [ ".extended" ],
+                "aliases": [
+                    "C# (extended)"
+                ],
+                "extensions": [
+                    ".extended"
+                ],
                 "configuration": "./language-configuration.json"
             },
             {
                 "id": "csharp"
             }
         ],
-        "grammars":
-        [
+        "grammars": [
             {
                 "language": "official",
                 "scopeName": "source.cs.official",
@@ -99,16 +151,14 @@
                 "path": "./syntaxes/source.cs.json"
             }
         ],
-        "themes":
-        [
+        "themes": [
             {
                 "label": "eppz!",
                 "uiTheme": "vs-dark",
                 "path": "./themes/default/eppz-code.json"
             }
         ],
-        "commands":
-        [
+        "commands": [
             {
                 "command": "eppz.code.popUpReview",
                 "title": "Pop up review notification for eppz! (C# theme for Unity)"
@@ -118,14 +168,11 @@
                 "title": "Reset review notification counters for eppz! (C# theme for Unity)"
             }
         ],
-        "configuration":
-        {
+        "configuration": {
             "type": "object",
             "title": "eppz! (C# theme for Unity) configuration",
-            "properties":
-            {
-                "eppz-code.disableAnalytics":
-                {
+            "properties": {
+                "eppz-code.disableAnalytics": {
                     "type": "boolean",
                     "default": false,
                     "description": "Disable usage analytics."
@@ -133,21 +180,20 @@
             }
         }
     },
-    "activationEvents": [ "*" ],
+    "activationEvents": [
+        "*"
+    ],
     "main": "./out/src/main",
-    "scripts":
-    {
+    "scripts": {
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "node ./node_modules/vscode/bin/test"
     },
-    "dependencies":
-    {
+    "dependencies": {
         "electron-google-analytics": "^0.0.16"
     },
-    "devDependencies":
-    {
+    "devDependencies": {
         "typescript": "^2.0.3",
         "vscode": "^1.0.0",
         "@types/node": "^6.0.40"

--- a/themes/default/eppz-code.html.json
+++ b/themes/default/eppz-code.html.json
@@ -1,0 +1,24 @@
+{
+	"name": "eppz! Code (markdown)",
+	"author": "Geri Borbás",
+	"comment": "Created by Geri Borbás (https://twitter.com/_eppz) © 2017 Creative Commons 4.0 BY-NC",
+	"include": "eppz-code.json.json",
+	"settings":
+	[
+
+
+	// Tag names and attributes
+	{
+		"name": "Tag name",
+		"scope": [ "entity.name.tag" ],
+		"settings": { "foreground": "#d88e79" }
+	},
+	{
+		"name": "Tag attribute",
+		"scope": [ "entity.other.attribute-name" ],  	
+		"settings": { "foreground": "#d9c679" }	
+
+	}
+
+	]
+}

--- a/themes/default/eppz-code.html.json
+++ b/themes/default/eppz-code.html.json
@@ -1,5 +1,5 @@
 {
-	"name": "eppz! Code (markdown)",
+	"name": "eppz! Code (html)",
 	"author": "Geri Borbás",
 	"comment": "Created by Geri Borbás (https://twitter.com/_eppz) © 2017 Creative Commons 4.0 BY-NC",
 	"include": "eppz-code.json.json",

--- a/themes/default/eppz-code.html.json
+++ b/themes/default/eppz-code.html.json
@@ -2,7 +2,6 @@
 	"name": "eppz! Code (html)",
 	"author": "Geri Borbás",
 	"comment": "Created by Geri Borbás (https://twitter.com/_eppz) © 2017 Creative Commons 4.0 BY-NC",
-	"include": "eppz-code.json.json",
 	"settings":
 	[
 

--- a/themes/default/eppz-code.json.json
+++ b/themes/default/eppz-code.json.json
@@ -2,6 +2,7 @@
 	"name": "eppz! Code (json)",
 	"author": "Geri Borbás",
 	"comment": "Created by Geri Borbás (https://twitter.com/_eppz) © 2017 Creative Commons 4.0 BY-NC",
+	"include": "eppz-code.html.json",
 	"settings":
 	[
 	

--- a/themes/default/eppz-code.root.json
+++ b/themes/default/eppz-code.root.json
@@ -208,7 +208,7 @@
 			"settings": { "foreground": "#d88e79" }
 		},
 		{
-			"name": "Tag name", // html
+			"name": "Tag name", // HOTFIX: html
 			"scope": [ "entity.name.tag" ],
 			"settings": { "foreground": "#d88e79" }
 		},
@@ -284,7 +284,7 @@
 			"settings": { "foreground": "#d9c679" }
 		},
 				{
-			"name": "Tag attribute", // html
+			"name": "Tag attribute", // HOTFIX: html
 			"scope": [ "entity.other.attribute-name" ],  	
 			"settings": { "foreground": "#d9c679" }
 		},

--- a/themes/default/eppz-code.root.json
+++ b/themes/default/eppz-code.root.json
@@ -207,6 +207,11 @@
 			"scope": [ "entity.name.type" ],
 			"settings": { "foreground": "#d88e79" }
 		},
+		{
+			"name": "Tag name", // html
+			"scope": [ "entity.name.tag" ],
+			"settings": { "foreground": "#d88e79" }
+		},
 
 
 	// Keywords.
@@ -276,6 +281,11 @@
 				"meta.object-literal.key", // HOTFIX: typescript	
 				"support.variable" // HOTFIX: typescript	
 			],
+			"settings": { "foreground": "#d9c679" }
+		},
+				{
+			"name": "Tag attribute", // html
+			"scope": [ "entity.other.attribute-name" ],  	
 			"settings": { "foreground": "#d9c679" }
 		},
 		{

--- a/themes/default/eppz-code.root.json
+++ b/themes/default/eppz-code.root.json
@@ -207,11 +207,6 @@
 			"scope": [ "entity.name.type" ],
 			"settings": { "foreground": "#d88e79" }
 		},
-		{
-			"name": "Tag name", // HOTFIX: html
-			"scope": [ "entity.name.tag" ],
-			"settings": { "foreground": "#d88e79" }
-		},
 
 
 	// Keywords.
@@ -281,11 +276,6 @@
 				"meta.object-literal.key", // HOTFIX: typescript	
 				"support.variable" // HOTFIX: typescript	
 			],
-			"settings": { "foreground": "#d9c679" }
-		},
-				{
-			"name": "Tag attribute", // HOTFIX: html
-			"scope": [ "entity.other.attribute-name" ],  	
 			"settings": { "foreground": "#d9c679" }
 		},
 		{


### PR DESCRIPTION
used existing color them to color HTML tag and attributes (see example of new output below, where all but strings used to be in white)

![image](https://user-images.githubusercontent.com/5218249/45440911-9b7a6800-b68b-11e8-9400-9e491b518328.png)
